### PR TITLE
Hotfix spamming chg dir evnt

### DIFF
--- a/src/main/view/KeyboardListener.cpp
+++ b/src/main/view/KeyboardListener.cpp
@@ -44,12 +44,12 @@ void KeyboardListener::inGameUpdate() {
 	std::array<bool, sf::Keyboard::KeyCount> currentState;
 	
 	currentState[sf::Keyboard::Right] = sf::Keyboard::isKeyPressed(sf::Keyboard::Right);
-	currentState[sf::Keyboard::Down] = sf::Keyboard::isKeyPressed(sf::Keyboard::Down);
-	currentState[sf::Keyboard::Left] = sf::Keyboard::isKeyPressed(sf::Keyboard::Left);
+	currentState[sf::Keyboard::Down ] = sf::Keyboard::isKeyPressed(sf::Keyboard::Down);
+	currentState[sf::Keyboard::Left ] = sf::Keyboard::isKeyPressed(sf::Keyboard::Left);
 	
 	if (currentState[sf::Keyboard::Right] != previousState[sf::Keyboard::Right] ||
-		currentState[sf::Keyboard::Down] != previousState[sf::Keyboard::Down] || 
-		currentState[sf::Keyboard::Left] != previousState[sf::Keyboard::Left]) {			//Direction Keys have changed
+		currentState[sf::Keyboard::Down ] != previousState[sf::Keyboard::Down ] || 
+		currentState[sf::Keyboard::Left ] != previousState[sf::Keyboard::Left ]) {			//Direction Keys have changed
 		
 		ChangePlayerDirectionEvent changePlayerDirectionEvent(NONE);
 		
@@ -87,16 +87,14 @@ void KeyboardListener::inGameUpdate() {
 					}
 				}
 			}
-	
 			changePlayerDirectionEvent = ChangePlayerDirectionEvent(newDir);
 		}
 		
 		eventManager->fireEvent(changePlayerDirectionEvent);
 		
 		previousState[sf::Keyboard::Right] = sf::Keyboard::isKeyPressed(sf::Keyboard::Right);
-		previousState[sf::Keyboard::Down] = sf::Keyboard::isKeyPressed(sf::Keyboard::Down);
-		previousState[sf::Keyboard::Left] = sf::Keyboard::isKeyPressed(sf::Keyboard::Left);
-
+		previousState[sf::Keyboard::Down ] = sf::Keyboard::isKeyPressed(sf::Keyboard::Down);
+		previousState[sf::Keyboard::Left ] = sf::Keyboard::isKeyPressed(sf::Keyboard::Left);
 	}
 	
 	if (sf::Keyboard::isKeyPressed(sf::Keyboard::P) != previousState[sf::Keyboard::P])  {

--- a/src/main/view/KeyboardListener.cpp
+++ b/src/main/view/KeyboardListener.cpp
@@ -47,7 +47,9 @@ void KeyboardListener::inGameUpdate() {
 	currentState[sf::Keyboard::Down] = sf::Keyboard::isKeyPressed(sf::Keyboard::Down);
 	currentState[sf::Keyboard::Left] = sf::Keyboard::isKeyPressed(sf::Keyboard::Left);
 	
-	if (currentState != previousState) {			//Keys have changed
+	if (currentState[sf::Keyboard::Right] != previousState[sf::Keyboard::Right] ||
+		currentState[sf::Keyboard::Down] != previousState[sf::Keyboard::Down] || 
+		currentState[sf::Keyboard::Left] != previousState[sf::Keyboard::Left]) {			//Direction Keys have changed
 		
 		ChangePlayerDirectionEvent changePlayerDirectionEvent(NONE);
 		
@@ -85,11 +87,16 @@ void KeyboardListener::inGameUpdate() {
 					}
 				}
 			}
+	
 			changePlayerDirectionEvent = ChangePlayerDirectionEvent(newDir);
 		}
 		
 		eventManager->fireEvent(changePlayerDirectionEvent);
 		
+		previousState[sf::Keyboard::Right] = sf::Keyboard::isKeyPressed(sf::Keyboard::Right);
+		previousState[sf::Keyboard::Down] = sf::Keyboard::isKeyPressed(sf::Keyboard::Down);
+		previousState[sf::Keyboard::Left] = sf::Keyboard::isKeyPressed(sf::Keyboard::Left);
+
 	}
 	
 	if (sf::Keyboard::isKeyPressed(sf::Keyboard::P) != previousState[sf::Keyboard::P])  {


### PR DESCRIPTION
It seems the problem was in two parts.

1) we weren't actually updating previousState when using direction keys.
2) We weren't actually comparing the array's properly. `currentState != previousState` was always coming back true even though they were the same.