### PR TITLE
F gameover

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The brain child and virginity shattering creation of Grizzly Studios
 | 2483       | 09/10/2014 |
 | 2850       | 13/10/2014 |
 | 3008       | 02/04/2015 |
+| 4281       | 15/04/2015 |
 
 On a unix system you can count the lines of code by running:
 

--- a/src/main/logic/Logic.cpp
+++ b/src/main/logic/Logic.cpp
@@ -64,6 +64,9 @@ void Logic::update(long int elapsed) {
 				player->advancer(bullets);
 			}
 			if (player->hasBeenHit()) {
+				if(player->livesLeft() <= 0){
+					Entity::toRemove.push_back(player);
+				}
 				//fireEvent of player hit to view
 			}
 		}
@@ -72,7 +75,7 @@ void Logic::update(long int elapsed) {
 
 		cleanUp();
 		spawn();
-		checkEnd();
+		checkEnd(interval);
 	}
 }
 
@@ -156,6 +159,7 @@ void Logic::generateLevel() {
 	generateBullets();
 	bulletInterval = 3000000;
 	nextBulletSpawn =  bulletInterval;
+	endCount = 0;
 }
 
 void Logic::generateBullets() {
@@ -217,7 +221,7 @@ void Logic::gameEnd(){
 	Entity::all.clear();
 }
 
-void Logic::checkEnd(){
+void Logic::checkEnd(long int interval){
 
 	int livesLeft = 0;
 	for (PlayerShPtr player : Player::all) {
@@ -225,7 +229,12 @@ void Logic::checkEnd(){
 	}
 
 	if(livesLeft <= 0){
-		GameStateChangedEvent gameStateChangedEvent(GAMEOVER);
-		eventManager->fireEvent(gameStateChangedEvent);
+		WARN << "endcount is " << endCount << std::endl;
+		if(endCount > 1000000){ /* Delay end for a bit */
+			GameStateChangedEvent gameStateChangedEvent(GAMEOVER);
+			eventManager->fireEvent(gameStateChangedEvent);
+		}
+		WARN << "adding " << interval << " to endCount" << std::endl;
+		endCount += interval;
 	}
 }

--- a/src/main/logic/Logic.h
+++ b/src/main/logic/Logic.h
@@ -56,6 +56,8 @@ private:
 	double advanceUntil;
 	bool startAdvance;
 	bool advancing;
+
+	int endCount;
 	
 	//Subroutines
 	void advancePlayers();
@@ -64,7 +66,7 @@ private:
 
 	void startNewGame();
 	void gameEnd();
-	void checkEnd();
+	void checkEnd(long int interval);
 	
 	void onChangePlayerDirection(ChangePlayerDirectionEvent &event);
 	void onGameStateChange(GameStateChangedEvent &event);


### PR DESCRIPTION
Changed game logic so that when a player is hit their sprite is deleted, the game waits for 1 second and then shows the gameover screen.

Also as part of this change there is some code that will later need to be refactoring and the start of the work needed for Enhancement #55